### PR TITLE
A method for detecting EncFS volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings
 eclipse_bin
 target
+.idea
+*.iml

--- a/src/main/java/org/mrpdaemon/sec/encfs/EncFSVolume.java
+++ b/src/main/java/org/mrpdaemon/sec/encfs/EncFSVolume.java
@@ -658,12 +658,12 @@ public class EncFSVolume {
 	/**
 	 * Checks whether the file or directory with the given path exists in the
 	 * volume
-	 * 
+	 *
 	 * @param path
 	 *            Absolute volume path of the file or directory
-	 * 
+	 *
 	 * @return true if path exists in the volume, false otherwise
-	 * 
+	 *
 	 * @throws EncFSCorruptDataException
 	 *             Filename encoding failed
 	 * @throws IOException
@@ -675,6 +675,20 @@ public class EncFSVolume {
 		String encryptedPath = EncFSCrypto.encodePath(this, path, ROOT_PATH);
 		return fileProvider.exists(encryptedPath);
 	}
+
+    /**
+     * Tests if the provided path contains EncFS volume
+     *
+     * @param path
+     *            Path to the presumed EncFS volume
+     * @return true if the volume is EncFS, false otherwise
+     * @throws IOException
+     *              File provider returned I/O error
+     */
+    public static boolean isEncFSVolume(String path) throws IOException {
+        EncFSFileProvider fileProvider = new EncFSLocalFileProvider(new File(path));
+        return (fileProvider.exists(fileProvider.getRootPath() + EncFSVolume.CONFIG_FILE_NAME));
+    }
 
 	/**
 	 * Creates a new EncFS volume on the supplied file provider using the

--- a/src/test/java/org/mrpdaemon/sec/encfs/EncFSVolumeIntegrationTest.java
+++ b/src/test/java/org/mrpdaemon/sec/encfs/EncFSVolumeIntegrationTest.java
@@ -48,6 +48,12 @@ public class EncFSVolumeIntegrationTest {
 	public void tearDown() throws Exception {
 	}
 
+    @Test
+    public void testIsEncFSVolume() throws IOException {
+         Assert.assertTrue(EncFSVolume.isEncFSVolume("test/encfs_samples/boxcryptor_1"));
+         Assert.assertFalse(EncFSVolume.isEncFSVolume("test/encfs_samples"));
+    }
+
 	@Test
 	public void testBoxCryptor_1_badPassword()
 			throws EncFSInvalidConfigException, EncFSCorruptDataException,


### PR DESCRIPTION
I've needed a method for checking if the file contains EncFS volume or not. It's based on EncFSConfigParser. parseConfig. It doesn't verify the config file, but provides me with an easy way how to decide when read or create the volume.
